### PR TITLE
refac / modal css

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -48,18 +48,16 @@ const Overlay = styled.div`
 const Contents = styled.div`
   box-sizing: border-box;
   position: relative;
-  top: 0px;
-  padding: 0 auto;
   border-radius: 10px;
   box-shadow: 0 0 6px 0 rgba(0, 0, 0, 0.5);
   background-color: #fff;
   text-align: center;
   width: 360px;
   max-width: 480px;
-  height: 300px;
+  height: 250px;
   transform: translateY(-50%);
   margin: 0 auto;
-  padding: 40px 20px;
+  padding: 60px 20px;
 `;
 
 export default Modal;

--- a/src/components/StatusModal/index.tsx
+++ b/src/components/StatusModal/index.tsx
@@ -1,5 +1,6 @@
 import Modal from 'components/Modal';
 import React from 'react';
+import styled from 'styled-components';
 
 type Props = {
   isOpenStatusModal: boolean;
@@ -12,9 +13,23 @@ const StatusModal = ({ isOpenStatusModal, setIsOpenStatusModal, statusMessage, o
   return (
     <Modal isOpen={isOpenStatusModal} setIsOpen={setIsOpenStatusModal}>
       <div>{statusMessage}</div>
-      <button onClick={onClose}>close</button>
+      <CloseStatusModalButton onClick={onClose}>close</CloseStatusModalButton>
     </Modal>
   );
 };
+
+const CloseStatusModalButton = styled.button`
+  width: 50%;
+  padding: 10px 30px;
+  margin: 30px auto 0 auto;
+
+  cursor: pointer;
+  display: block;
+
+  background: linear-gradient(to right, #ff105f, #ffad06);
+  border: 0;
+  outline: none;
+  border-radius: 30px;
+`;
 
 export default StatusModal;


### PR DESCRIPTION
refac / modal css 
원래 로그인, 회원가입 Modal도 영역 밖을 클릭하면 닫기 기능을 추가하려했으나 
로그인과 관련되서 닫기 버튼말고 밖을 클릭해도 닫힌다면 같은 로그인, 회원가입에 대한 오류메시지 인식이 힘들거 같아 빼기로 결정